### PR TITLE
Added support to add UIKit+AFNetworking using Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,11 +30,16 @@ let package = Package(name: "AFNetworking",
                                   .iOS(.v9),
                                   .tvOS(.v9),
                                   .watchOS(.v2)],
-                      products: [
-                                    .library(name: "AFNetworking",
-                                          targets: ["AFNetworking"])
+                      products: [.library(name: "AFNetworking",
+                                    targets: ["AFNetworking"]),
+                                .library(name: "AFNetworking",
+                                    targets: ["UIKit_AFNetworking"])
                                 ],
                       targets: [.target(name: "AFNetworking",
                                         path: "AFNetworking",
-                                        sources: ["AFNetworking/", "UIKit+AFNetworking/"],
-                                        publicHeadersPath: "")])
+                                        publicHeadersPath: ""),
+                                .target(name: "UIKit_AFNetworking",
+                                        path: "UIKit+AFNetworking",
+                                        publicHeadersPath: "")]
+                                ]
+                    )

--- a/Package.swift
+++ b/Package.swift
@@ -36,5 +36,5 @@ let package = Package(name: "AFNetworking",
                                 ],
                       targets: [.target(name: "AFNetworking",
                                         path: "AFNetworking",
-                                        sources: "UIKit+AFNetworking",
+                                        sources: ["UIKit+AFNetworking"],
                                         publicHeadersPath: "")])

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,11 @@ let package = Package(name: "AFNetworking",
                                   .iOS(.v9),
                                   .tvOS(.v9),
                                   .watchOS(.v2)],
-                      products: [.library(name: "AFNetworking",
-                                          targets: ["AFNetworking"])],
+                      products: [
+                                    .library(name: "AFNetworking",
+                                          targets: ["AFNetworking"])
+                                ],
                       targets: [.target(name: "AFNetworking",
                                         path: "AFNetworking",
+                                        sources: "UIKit+AFNetworking",
                                         publicHeadersPath: "")])

--- a/Package.swift
+++ b/Package.swift
@@ -36,5 +36,5 @@ let package = Package(name: "AFNetworking",
                                 ],
                       targets: [.target(name: "AFNetworking",
                                         path: "AFNetworking",
-                                        sources: ["UIKit+AFNetworking"],
+                                        sources: ["AFNetworking/", "UIKit+AFNetworking/"],
                                         publicHeadersPath: "")])

--- a/Package.swift
+++ b/Package.swift
@@ -40,5 +40,6 @@ let package = Package(name: "AFNetworking",
                                         publicHeadersPath: ""),
                                 .target(name: "UIKit_AFNetworking",
                                         path: "UIKit+AFNetworking",
+                                        sources: ["AFNetworking/"],
                                         publicHeadersPath: "")]
                     )

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(name: "AFNetworking",
                                         path: "AFNetworking",
                                         publicHeadersPath: ""),
                                 .target(name: "UIKit_AFNetworking",
+                                        dependencies: ["AFNetworking"],
                                         path: "UIKit+AFNetworking",
-                                        sources: ["AFNetworking/"],
                                         publicHeadersPath: "")]
                     )

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(name: "AFNetworking",
                                   .watchOS(.v2)],
                       products: [.library(name: "AFNetworking",
                                     targets: ["AFNetworking"]),
-                                .library(name: "AFNetworking",
+                                .library(name: "UIKit_AFNetworking",
                                     targets: ["UIKit_AFNetworking"])
                                 ],
                       targets: [.target(name: "AFNetworking",

--- a/Package.swift
+++ b/Package.swift
@@ -41,5 +41,4 @@ let package = Package(name: "AFNetworking",
                                 .target(name: "UIKit_AFNetworking",
                                         path: "UIKit+AFNetworking",
                                         publicHeadersPath: "")]
-                                ]
                     )


### PR DESCRIPTION
### Issue Link :link:
https://github.com/AFNetworking/AFNetworking/issues/4616

### Goals :soccer:
Added support to add UIKit+AFNetworking using Swift Package Manager

### Implementation Details :construction:
- Added target `UIKit_AFNetworking` depends upon target `AFNetworking`

### Testing Details :mag:
Create a project and try to add AFNetworking or UIKit_AFNetworking target.